### PR TITLE
Use square brackets to look up group.

### DIFF
--- a/tasks/checks/check_firewall.yml
+++ b/tasks/checks/check_firewall.yml
@@ -17,7 +17,7 @@
   local_action: shell set -o pipefail && nmap -p 6789 {{ item }} {{ hostvars[item]['ansible_' + monitor_interface]['ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
-  with_items: groups.{{ mon_group_name }}
+  with_items: groups[mon_group_name]
   register: monportstate
   when:
     check_firewall and
@@ -39,7 +39,7 @@
   local_action: shell set -o pipefail && nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
-  with_items: groups.{{ osd_group_name }}
+  with_items: groups[osd_group_name]
   register: osdrangestate
   when:
     check_firewall and
@@ -61,7 +61,7 @@
   local_action: shell set -o pipefail && nmap -p 6800-7300 {{ item }} {{ hostvars[item]['ansible_default_ipv4']['address'] }} | grep -sqo filtered
   changed_when: false
   failed_when: false
-  with_items: groups.{{ mds_group_name }}
+  with_items: groups[mds_group_name]
   register: mdsrangestate
   when:
     check_firewall and


### PR DESCRIPTION
This change makes it so that square brackets, rather
than dot notation, is used to look up groups. It is
common for group names to have hyphens in them, which
breaks when using dot notation.